### PR TITLE
FreeBSD support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,18 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+
+freebsd_task:
+  name: $TOOLCHAIN x86_64-unknown-freebsd
+  env:
+    matrix:
+      - TOOLCHAIN: stable
+      - TOOLCHAIN: beta
+      - TOOLCHAIN: nightly
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh -y --default-toolchain $TOOLCHAIN
+  build_script:
+    - $HOME/.cargo/bin/rustup run $TOOLCHAIN cargo build
+  test_script:
+    - $HOME/.cargo/bin/rustup run $TOOLCHAIN cargo test


### PR DESCRIPTION
Hi, thanks for your work! I would like to expand it a little bit by adding FreeBSD support. WDYT?

FreeBSD is not supported by the library, even though its `ptrace`
implementation supports `PT_IO` call, using which we can read process
memory directly and without switching to root.

This change
* adds FreeBSD support, using native `ptrace` syscall.
  Under the hood, `ptrace` changes traced process parent and stops the
  traced process, allowing further introspection. All major modern BSD
  OSes support `PT_IO` in their ptraces, which allow reading / writing
  arbitrary data in / from traced process memory.

* Adds support for Cirrus CI, the same CI libc uses for testing
  FreeBSD code.