### PR TITLE
Fix TravisCI for Darwin.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 os:
 - linux
 - osx
+# Darwin image without system integrity protection
+osx_image: xcode6.4
 # necessary for `travis-cargo coveralls --no-sudo`
 addons:
   apt:
@@ -24,7 +26,7 @@ before_install:
 
 # load travis-cargo
 before_script:
-  - pip2 install 'travis-cargo<0.2' --user
+  - sudo easy_install 'travis-cargo<0.2'
   - if [[ -e ~/Library/Python/2.7/bin ]]; then export PATH=~/Library/Python/2.7/bin:$PATH; fi
   - if [[ -e ~/.local/bin ]]; then export PATH=~/.local/bin:$PATH; fi
   - echo PATH is $PATH


### PR DESCRIPTION
Since 10.11 OSX ships with System Integrity protection which might
prevent certain actions on processes we do not own (such as `vm_read`
syscall).

This change pins Travis osx image to `xcode6.4` which is from pre-SIP
era.